### PR TITLE
Fixing sylvan_fprintdot to generate F and T nodes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Makefile.in
 *.lo
 *.o
 *.la
+
+# MacOS
+.DS_Store


### PR DESCRIPTION
The original implementation used 0 as its only termination node, so all graphs had one result which was 0. Also, you can't use 1 as the termination node since that is a potential variable.

This fix uses the characters 'F' and 'T' to represent false and true termination nodes. I had to also pass in the MARK status (is it inverted) into the recursive dot creation algorithm to capture which node was the final destination.