### PR TITLE
lace: correctly use sched_getaffinity.

### DIFF
--- a/src/lace.c
+++ b/src/lace.c
@@ -17,7 +17,9 @@
 
 #define _GNU_SOURCE
 #include <errno.h> // for errno
-#include <sched.h> // for sched_getaffinity
+#ifdef __linux__
+#   include <sched.h> // for sched_getaffinity
+#endif
 #include <stdio.h>  // for fprintf
 #include <stdlib.h> // for memalign, malloc
 #include <string.h> // for memset
@@ -827,7 +829,7 @@ lace_init(unsigned int _n_workers, size_t dqsize)
     n_nodes = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_NODE);
     n_cores = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE);
     n_pus = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
-#elif defined(sched_getaffinity)
+#elif defined(__linux__)
     cpu_set_t cs;
     CPU_ZERO(&cs);
     sched_getaffinity(0, sizeof(cs), &cs);


### PR DESCRIPTION
Checking for defined functions with defined(sched_getaffinity) is
not possible, it can only be used to check if macros are defined.

Without this commit sched_getaffinity would never be called, meaning
that lace was not able to correctly determine the number of available
cpus on systems that use e.g. docker.