### PR TITLE
Remove hwloc dependency from sylvan.pc.

### DIFF
--- a/sylvan.pc.cmake.in
+++ b/sylvan.pc.cmake.in
@@ -7,4 +7,4 @@ URL: @PROJECT_URL@
 Version: @PROJECT_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lsylvan -lgmp -lpthread -lm
-Requires: hwloc
+


### PR DESCRIPTION
Hwloc is already no longer a mandatory dependency in cmake.