### PR TITLE
Changed function for checking powers of 2

### DIFF
--- a/src/sylvan_common.c
+++ b/src/sylvan_common.c
@@ -276,7 +276,7 @@ static size_t table_min = 0, table_max = 0, cache_min = 0, cache_max = 0;
 static int
 is_power_of_two(size_t size)
 {
-    return __builtin_popcount(size) == 1 ? 1 : 0;
+    return (size != 0) && ((size & (size-1)) == 0);
 }
 
 void


### PR DESCRIPTION
Changed how to check whether a number is a power of 2.
Before `__builtin_popcount`was used but it only takes `unsigned int` as input, which leads to problems for large numbers. In my case `is_power_of_two` for 2^32 returned 0, because of some overflow.
The pull request replaces this function by using bit operations instead.
For an explanation of the bit operations see this [Stack Overflow response](https://stackoverflow.com/a/600306).