### PR TITLE
Fixed a condition that was unintentionally always false.

### DIFF
--- a/src/sylvan_common.c
+++ b/src/sylvan_common.c
@@ -306,8 +306,8 @@ sylvan_set_sizes(size_t min_tablesize, size_t max_tablesize, size_t min_cachesiz
 void
 sylvan_set_limits(size_t memorycap, int table_ratio, int initial_ratio)
 {
-    if (table_ratio > 10 && table_ratio < 10) {
-        fprintf(stderr, "sylvan_set_limits: table_ratio unreasonable (between -10 and 10)\n");
+    if (table_ratio < -10 || table_ratio > 10) {
+        fprintf(stderr, "sylvan_set_limits: table_ratio unreasonable (should be between -10 and 10)\n");
         exit(1);
     }
 


### PR DESCRIPTION
The function sylvan_set_limits required the table_ratio parameter to be between -10 and 10. However, the condition of this check was always false.