### PR TITLE
Portable C11/C++11 memory fence

### DIFF
--- a/src/lace.h
+++ b/src/lace.h
@@ -20,7 +20,13 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <pthread.h> /* for pthread_t */
-
+#ifdef __cplusplus
+#include <thread>
+using std::atomic_thread_fence;
+using std::memory_order_seq_cst;
+#else
+#include <stdatomic.h>
+#endif
 #ifndef __LACE_H__
 #define __LACE_H__
 
@@ -297,7 +303,7 @@ void lace_yield(WorkerP *__lace_worker, Task *__lace_dq_head);
 #endif
 
 #ifndef mfence
-#define mfence() { asm volatile("mfence" ::: "memory"); }
+#define mfence() { atomic_thread_fence(memory_order_seq_cst); }
 #endif
 
 /* Compiler specific branch prediction optimization */


### PR DESCRIPTION
`mfence` instruction is only available on x86 while [atomic_thread_fence](https://en.cppreference.com/w/c/atomic/atomic_thread_fence) is a C11/C++11 standard and is supported by all major compilers (e.g. gcc since version 4.8). 
This patch allows on other CPU architectures, including aarch64/arm64.
Tested on macOS/M1.