### PR TITLE
Add message about Rust bindings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Bindings for other languages than C/C++ also exist:
 -  Java/JNI bindings: https://github.com/utwente-fmt/jsylvan (outdated prototype)
 -  Haskell bindings: https://github.com/adamwalker/sylvan-haskell
 -  Python bindings: https://github.com/johnyf/dd
+-  Rust bindings: https://github.com/daemontus/sylvan-sys
 
 ## Documentation
 


### PR DESCRIPTION
Hi! 

I have a need for using Sylvan from Rust, so I made a small binding library [here](https://github.com/daemontus/sylvan-sys). Maybe someone else will want to use it as well.

At the moment, it is just a copy of the C API (almost) directly mirrored into Rust (hence the "unsafe" moniker). The logical next step would be to create bindings on top of these, which actually use Rust types to ensure memory safety and other invariants when interfacing with Sylvan. I may have time to build something like that later this year, but I'm not promising anything yet.