### PR TITLE
Recursive implementation of zdd_eval

### DIFF
--- a/src/sylvan_int.h
+++ b/src/sylvan_int.h
@@ -116,6 +116,7 @@ static const uint64_t CACHE_ZDD_EXISTS              = (90LL<<40);
 static const uint64_t CACHE_ZDD_PROJECT             = (91LL<<40);
 static const uint64_t CACHE_ZDD_ISOP                = (92LL<<40);
 static const uint64_t CACHE_ZDD_COVER_TO_BDD        = (93LL<<40);
+static const uint64_t CACHE_ZDD_EVAL                = (94LL<<40);
 
 #ifdef __cplusplus
 }

--- a/src/sylvan_stats.h
+++ b/src/sylvan_stats.h
@@ -103,6 +103,7 @@ typedef enum {
     OPCOUNTER(ZDD_PROJECT),
     OPCOUNTER(ZDD_ISOP),
     OPCOUNTER(ZDD_COVER_TO_BDD),
+    OPCOUNTER(ZDD_EVAL),
 
     /* Other counters */
     SYLVAN_GC_COUNT,

--- a/src/sylvan_zdd.c
+++ b/src/sylvan_zdd.c
@@ -519,17 +519,46 @@ zdd_nithvar(uint32_t var)
  * Evaluate a ZDD, assigning <value> (1 or 0) to <variable>;
  * <variable> is the current variable in the domain
  */
-ZDD
-zdd_eval(ZDD dd, uint32_t variable, int value)
+TASK_IMPL_3(ZDD, zdd_eval, ZDD, dd, uint32_t, variable, int, value)
 {
     // If <variable> was skipped, return false if value is true
     if (zdd_isleaf(dd)) return value ? zdd_false : dd;
     zddnode_t n = ZDD_GETNODE(dd);
     uint32_t var = zddnode_getvariable(n);
     if (variable < var) return value ? zdd_false : dd;
-    assert(variable == var);
-    // Otherwise, follow low/high edge...
-    return value ? zddnode_high(dd, n) : zddnode_low(dd, n);
+
+    // If <variable> is the current top variable, follow low/high edge
+    if (variable == var) return value ? zddnode_high(dd, n) : zddnode_low(dd, n);
+
+    // Otherwise
+    // Count operation
+    sylvan_stats_count(ZDD_EVAL);
+
+    // Check cache
+    ZDD result;
+    if (cache_get3(CACHE_ZDD_EVAL, dd, variable, value, &result)) {
+        sylvan_stats_count(ZDD_EVAL_CACHED);
+        return result;
+    }
+
+    // Cache miss -> recursion
+    ZDD n0 = zddnode_low(dd, n);
+    ZDD n1 = zddnode_high(dd, n);
+
+    zdd_refs_spawn(SPAWN(zdd_eval, n0, variable, value));
+    ZDD high = CALL(zdd_eval, n1, variable, value);
+    zdd_refs_push(high);
+    ZDD low = zdd_refs_sync(SYNC(zdd_eval));
+    zdd_refs_pop(1);
+
+    result = zdd_makenode(var, low, high);
+
+    // Store result in cache
+    if (cache_put3(CACHE_ZDD_EVAL, dd, variable, value, result)) {
+        sylvan_stats_count(ZDD_EVAL_CACHEDPUT);
+    }
+
+    return result;
 }
 
 /**

--- a/src/sylvan_zdd.h
+++ b/src/sylvan_zdd.h
@@ -113,7 +113,8 @@ ZDD zdd_gethigh(ZDD dd);
 /**
  * Evaluate a ZDD, assigning <value> (1 or 0) to <variables>.
  */
-ZDD zdd_eval(ZDD dd, uint32_t var, int value);
+TASK_DECL_3(ZDD, zdd_eval, ZDD, uint32_t, int);
+#define zdd_eval(dd, var, value) RUN(zdd_eval, dd, var, value)
 
 /**
  * Obtain a ZDD representing a positive literal of variable <var>.

--- a/test/test_zdd.c
+++ b/test/test_zdd.c
@@ -98,6 +98,26 @@ TASK_0(int, test_zdd_eval)
     test_assert(zdd_eval(zdd, 6, 1) == zdd_false);
     test_assert(zdd_eval(zdd, 6, 0) != zdd_false);
 
+    /**
+     * Test that the evaluation works correctly also for variables that are not in the root.
+    */
+
+    zdd = zdd_from_mtbdd(dd, dom);
+    test_assert(zdd_eval(zdd, 2, 1) != zdd_false);
+    test_assert(zdd_eval(zdd, 3, 1) != zdd_false);
+    test_assert(zdd_eval(zdd, 5, 1) != zdd_false);
+    test_assert(zdd_eval(zdd, 2, 0) == zdd_eval(zdd, 2, 1));
+    test_assert(zdd_eval(zdd, 3, 0) == zdd_eval(zdd, 3, 1));
+    test_assert(zdd_eval(zdd, 5, 0) == zdd_eval(zdd, 5, 1));
+    zdd = zdd_eval(zdd, 6, 0);
+    zdd = zdd_eval(zdd, 5, 0);
+    zdd = zdd_eval(zdd, 4, 0);
+    zdd = zdd_eval(zdd, 3, 0);
+    zdd = zdd_eval(zdd, 2, 0);
+    zdd = zdd_eval(zdd, 1, 0);
+    test_assert(zdd_eval(zdd, 0, 1) == zdd_false);
+    test_assert(zdd_eval(zdd, 0, 0) == zdd_true);
+
     return 0;
 }
 


### PR DESCRIPTION
I have re-implemented the `zdd_eval()` operator to work also in the general case, i.e. for variables that are not in the root of the evaluated ZDD. The algorithm is taken from the following paper, where it's called `subset0`, resp. `subset1`:

Shin-ichi Minato. 1993. Zero-suppressed BDDs for set manipulation in combinatorial problems. In Proceedings of the 30th international Design Automation Conference (DAC '93). Association for Computing Machinery, New York, NY, USA, 272–277. https://doi.org/10.1145/157485.164890

I have also added some test cases for this operation and have since used it as a subroutine in other algorithms, where it seems to be yielding correct results. I hope I have correctly used the library's internals (caching, protection from GC, ...).