### PR TITLE
Small changes to fix installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,14 +18,14 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
     FetchContent_Declare(
         lace
         GIT_REPOSITORY https://github.com/trolando/lace.git
-        GIT_TAG        v1.4.1
+        GIT_TAG        v1.4.2
         FIND_PACKAGE_ARGS
     )
 else()
     FetchContent_Declare(
         lace
         GIT_REPOSITORY https://github.com/trolando/lace.git
-        GIT_TAG        v1.4.1
+        GIT_TAG        v1.4.2
     )
 endif()
 FetchContent_MakeAvailable(lace)

--- a/src/sylvan.pc.in
+++ b/src/sylvan.pc.in
@@ -7,4 +7,4 @@ URL: @PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lsylvan @PKGC_LINK_GMP@
-Requires: lace>=1.4.2
+Requires: lace >= 1.4.2


### PR DESCRIPTION
There are some problem with the latest sylvan commit in terms of installing.
If you install it as is, you get this error when checking for sylvan in pkgconf
![sylvan error 1](https://github.com/trolando/sylvan/assets/96649204/ec53bf7a-f336-4132-bf96-bb86020ad10c)
It looks for the package "lace>=1.4.2". It's a small mistake in src/[sylvan.pc.in:10](http://sylvan.pc.in:10/).
"lace>=1.4.2" need spaces so it becomes "lace >= 1.4.2".


BUT when this is done there is another error.   
![sylvan error 2](https://github.com/trolando/sylvan/assets/96649204/b3f050d0-b430-4cb8-b8a5-5653b9ff90a7)
This is because lace 1.4.1 is installed and it doesn't export lace.pc.
A bump of lace version in CMakelists.txt to 1.4.2 solves this. 