### PR TITLE
Fix Sylvan Cannot be Compiled as a Submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ FetchContent_MakeAvailable(lace)
 # Add the Sylvan library target
 add_subdirectory(src)
 
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     # If we are in the root, add some options to build examples/tests
     option(SYLVAN_BUILD_EXAMPLES "Build example tools" ON)
     option(SYLVAN_BUILD_DOCS "Build documentation" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,7 +118,7 @@ install(EXPORT sylvan-targets
 include(CMakePackageConfigHelpers)
 
 configure_package_config_file(
-    ${CMAKE_SOURCE_DIR}/cmake/sylvan-config.cmake.in
+    ${PROJECT_SOURCE_DIR}/cmake/sylvan-config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/sylvan-config.cmake
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sylvan
 )


### PR DESCRIPTION
Note that `CMAKE_SOURCE_DIR` and `PROJECT_SOURCE_DIR` are two different variables. The former is the root of the entire tree (possibly a dependent project) whereas the latter is the latest call to `project()` (which is the Sylvan root folder in this case).

- [x] Does it now work again as a submodule? Yes, I have tested this works as intended on my benchmarking repository. With this fix, everything compiles and runs with the latest version of Sylvan.
- [x] Does it break installation? No, `sudo make install` indeed copies the desired files to */usr/local/...* as intended.