### PR TITLE
C++ Constructor Clean-up and Move semantics

### DIFF
--- a/src/sylvan_obj.cpp
+++ b/src/sylvan_obj.cpp
@@ -782,8 +782,7 @@ Mtbdd::operator*(const Mtbdd& other) const
 Mtbdd&
 Mtbdd::operator*=(const Mtbdd& other)
 {
-    mtbdd = mtbdd_times(mtbdd, other.mtbdd);
-    return *this;
+    return (*this = *this * other);
 }
 
 Mtbdd
@@ -795,8 +794,7 @@ Mtbdd::operator+(const Mtbdd& other) const
 Mtbdd&
 Mtbdd::operator+=(const Mtbdd& other)
 {
-    mtbdd = mtbdd_plus(mtbdd, other.mtbdd);
-    return *this;
+    return (*this = *this + other);
 }
 
 Mtbdd
@@ -808,8 +806,7 @@ Mtbdd::operator-(const Mtbdd& other) const
 Mtbdd&
 Mtbdd::operator-=(const Mtbdd& other)
 {
-    mtbdd = mtbdd_minus(mtbdd, other.mtbdd);
-    return *this;
+    return (*this = *this - other);
 }
 
 Mtbdd

--- a/src/sylvan_obj.cpp
+++ b/src/sylvan_obj.cpp
@@ -95,8 +95,7 @@ Bdd::operator*(const Bdd& other) const
 Bdd&
 Bdd::operator*=(const Bdd& other)
 {
-    bdd = sylvan_and(bdd, other.bdd);
-    return *this;
+    return (*this = *this * other);
 }
 
 Bdd
@@ -108,8 +107,7 @@ Bdd::operator&(const Bdd& other) const
 Bdd&
 Bdd::operator&=(const Bdd& other)
 {
-    bdd = sylvan_and(bdd, other.bdd);
-    return *this;
+    return (*this = *this & other);
 }
 
 Bdd
@@ -121,8 +119,7 @@ Bdd::operator+(const Bdd& other) const
 Bdd&
 Bdd::operator+=(const Bdd& other)
 {
-    bdd = sylvan_or(bdd, other.bdd);
-    return *this;
+    return (*this = *this + other);
 }
 
 Bdd
@@ -134,8 +131,7 @@ Bdd::operator|(const Bdd& other) const
 Bdd&
 Bdd::operator|=(const Bdd& other)
 {
-    bdd = sylvan_or(bdd, other.bdd);
-    return *this;
+    return (*this = *this | other);
 }
 
 Bdd
@@ -147,8 +143,7 @@ Bdd::operator^(const Bdd& other) const
 Bdd&
 Bdd::operator^=(const Bdd& other)
 {
-    bdd = sylvan_xor(bdd, other.bdd);
-    return *this;
+    return (*this = *this ^ other);
 }
 
 Bdd
@@ -160,8 +155,7 @@ Bdd::operator-(const Bdd& other) const
 Bdd&
 Bdd::operator-=(const Bdd& other)
 {
-    bdd = sylvan_and(bdd, sylvan_not(other.bdd));
-    return *this;
+    return (*this = *this - other);
 }
 
 Bdd

--- a/src/sylvan_obj.cpp
+++ b/src/sylvan_obj.cpp
@@ -754,6 +754,13 @@ Mtbdd::operator=(const Mtbdd& right)
     return *this;
 }
 
+Mtbdd&
+Mtbdd::operator=(Mtbdd&& right)
+{
+  mtbdd = right.mtbdd;
+  return *this;
+}
+
 Mtbdd
 Mtbdd::operator!() const
 {

--- a/src/sylvan_obj.cpp
+++ b/src/sylvan_obj.cpp
@@ -42,6 +42,13 @@ Bdd::operator=(const Bdd& right)
     return *this;
 }
 
+Bdd&
+Bdd::operator=(Bdd&& right)
+{
+  bdd = right.bdd;
+  return *this;
+}
+
 bool
 Bdd::operator<=(const Bdd& other) const
 {

--- a/src/sylvan_obj.hpp
+++ b/src/sylvan_obj.hpp
@@ -711,6 +711,7 @@ public:
     bool operator==(const Mtbdd& other) const;
     bool operator!=(const Mtbdd& other) const;
     Mtbdd& operator=(const Mtbdd& right);
+    Mtbdd& operator=(Mtbdd&& right);
     Mtbdd operator!() const;
     Mtbdd operator~() const;
     Mtbdd operator*(const Mtbdd& other) const;

--- a/src/sylvan_obj.hpp
+++ b/src/sylvan_obj.hpp
@@ -35,11 +35,46 @@ class Bdd {
     friend class Mtbdd;
 
 public:
-    Bdd() { bdd = sylvan_false; sylvan_protect(&bdd); }
-    Bdd(const BDD from) : bdd(from) { sylvan_protect(&bdd); }
-    Bdd(const Bdd &from) : bdd(from.bdd) { sylvan_protect(&bdd); }
-    Bdd(const uint32_t var) { bdd = sylvan_ithvar(var); sylvan_protect(&bdd); }
-    ~Bdd() { sylvan_unprotect(&bdd); }
+    /**
+     * @brief Default constructor, representing *False*.
+     */
+    Bdd()
+    {
+        bdd = sylvan_false;
+        sylvan_protect(&bdd);
+    }
+
+    /**
+     * @brief Wraps a raw BDD from Sylvan's C interface into a Bdd object.
+     */
+    Bdd(const BDD from)
+        : bdd(from)
+    {
+        sylvan_protect(&bdd);
+    }
+
+    /**
+     * @brief Copy construction of another Bdd.
+     */
+    Bdd(const Bdd &from)
+        : bdd(from.bdd)
+    {
+        sylvan_protect(&bdd);
+    }
+
+    /**
+     * @brief Construction of the Bdd represnting a variable index in its positive form.
+     */
+    Bdd(const uint32_t var)
+    {
+        bdd = sylvan_ithvar(var);
+        sylvan_protect(&bdd);
+    }
+
+    ~Bdd()
+    {
+        sylvan_unprotect(&bdd);
+    }
 
     /**
      * @brief Creates a Bdd representing just the variable index in its positive form

--- a/src/sylvan_obj.hpp
+++ b/src/sylvan_obj.hpp
@@ -36,22 +36,27 @@ class Bdd {
 
 public:
     /**
-     * @brief Default constructor, representing *False*.
-     */
-    Bdd()
-    {
-        bdd = sylvan_false;
-        sylvan_protect(&bdd);
-    }
-
-    /**
      * @brief Wraps a raw BDD from Sylvan's C interface into a Bdd object.
      */
     Bdd(const BDD from)
         : bdd(from)
     {
-        sylvan_protect(&bdd);
+      sylvan_protect(&bdd);
     }
+
+    /**
+     * @brief Default constructor, representing *False*.
+     */
+    Bdd()
+        : Bdd(sylvan_false)
+    {}
+
+    /**
+     * @brief Construction of the Bdd represnting a variable index in its positive form.
+     */
+    Bdd(const uint32_t var)
+        : Bdd(sylvan_ithvar(var))
+    {}
 
     /**
      * @brief Copy construction of another Bdd.
@@ -59,15 +64,6 @@ public:
     Bdd(const Bdd &from)
         : bdd(from.bdd)
     {
-        sylvan_protect(&bdd);
-    }
-
-    /**
-     * @brief Construction of the Bdd represnting a variable index in its positive form.
-     */
-    Bdd(const uint32_t var)
-    {
-        bdd = sylvan_ithvar(var);
         sylvan_protect(&bdd);
     }
 

--- a/src/sylvan_obj.hpp
+++ b/src/sylvan_obj.hpp
@@ -62,10 +62,8 @@ public:
      * @brief Copy construction of another Bdd.
      */
     Bdd(const Bdd &from)
-        : bdd(from.bdd)
-    {
-        sylvan_protect(&bdd);
-    }
+        : Bdd(from.bdd)
+    {}
 
     /**
      * @brief Move construction from Bdd.

--- a/src/sylvan_obj.hpp
+++ b/src/sylvan_obj.hpp
@@ -67,6 +67,13 @@ public:
         sylvan_protect(&bdd);
     }
 
+    /**
+     * @brief Move construction from Bdd.
+     */
+    Bdd(Bdd &&from)
+        : Bdd(from.bdd)
+    {}
+
     ~Bdd()
     {
         sylvan_unprotect(&bdd);

--- a/src/sylvan_obj.hpp
+++ b/src/sylvan_obj.hpp
@@ -628,6 +628,13 @@ public:
     {}
 
     /**
+     * @brief Move construction
+     */
+    Mtbdd(Mtbdd &&from)
+        : Mtbdd(from.mtbdd)
+    {}
+
+    /**
      * @brief Conversion construction from Bdd object.
      */
     Mtbdd(const Bdd &from)

--- a/src/sylvan_obj.hpp
+++ b/src/sylvan_obj.hpp
@@ -120,6 +120,7 @@ public:
     bool operator==(const Bdd& other) const;
     bool operator!=(const Bdd& other) const;
     Bdd& operator=(const Bdd& right);
+    Bdd& operator=(Bdd&& right);
     bool operator<=(const Bdd& other) const;
     bool operator>=(const Bdd& other) const;
     bool operator<(const Bdd& other) const;

--- a/src/sylvan_obj.hpp
+++ b/src/sylvan_obj.hpp
@@ -382,57 +382,69 @@ public:
     /**
      * @brief Create a new empty set.
      */
-    BddSet() : set(Bdd::bddOne()) {}
+    BddSet()
+        : set(Bdd::bddOne())
+    {}
 
     /**
      * @brief Wrap the BDD cube <other> in a set.
      */
-    BddSet(const Bdd &other) : set(other) {}
+    BddSet(const Bdd &other)
+        : set(other)
+    {}
 
     /**
      * @brief Create a copy of the set <other>.
      */
-    BddSet(const BddSet &other) : set(other.set) {}
+    BddSet(const BddSet &other)
+        : set(other.set)
+    {}
 
     /**
      * @brief Add the variable <variable> to this set.
      */
-    void add(uint32_t variable) {
+    void add(uint32_t variable)
+    {
         set *= Bdd::bddVar(variable);
     }
 
     /**
      * @brief Add all variables in the set <other> to this set.
      */
-    void add(BddSet &other) {
+    void add(BddSet &other)
+    {
         set *= other.set;
     }
 
     /**
      * @brief Remove the variable <variable> from this set.
      */
-    void remove(uint32_t variable) {
+    void remove(uint32_t variable)
+    {
         set = set.ExistAbstract(Bdd::bddVar(variable));
     }
 
     /**
      * @brief Remove all variables in the set <other> from this set.
      */
-    void remove(BddSet &other) {
+    void remove(BddSet &other)
+    {
         set = set.ExistAbstract(other.set);
     }
 
     /**
      * @brief Retrieve the head of the set. (The first variable.)
      */
-    uint32_t TopVar() const {
+    uint32_t TopVar() const
+    {
         return set.TopVar();
     }
 
     /**
      * @brief Retrieve the tail of the set. (The set containing all but the first variables.)
      */
-    BddSet Next() const {
+    BddSet Next() const
+    {
         Bdd then = set.Then();
         return BddSet(then);
     }
@@ -440,14 +452,16 @@ public:
     /**
      * @brief Return true if this set is empty, or false otherwise.
      */
-    bool isEmpty() const {
+    bool isEmpty() const
+    {
         return set.isOne();
     }
 
     /**
      * @brief Return true if this set contains the variable <variable>, or false otherwise.
      */
-    bool contains(uint32_t variable) const {
+    bool contains(uint32_t variable) const
+    {
         if (isEmpty()) return false;
         else if (TopVar() == variable) return true;
         else return Next().contains(variable);
@@ -456,7 +470,8 @@ public:
     /**
      * @brief Return the number of variables in this set.
      */
-    size_t size() const {
+    size_t size() const
+    {
         if (isEmpty()) return 0;
         else return 1 + Next().size();
     }
@@ -465,7 +480,8 @@ public:
      * @brief Create a set containing the <length> variables in <arr>.
      * It is advised to have the variables in <arr> in ascending order.
      */
-    static BddSet fromArray(BDDVAR *arr, size_t length) {
+    static BddSet fromArray(BDDVAR *arr, size_t length)
+    {
         BddSet set;
         for (size_t i = 0; i < length; i++) {
             set.add(arr[length-i-1]);
@@ -477,7 +493,8 @@ public:
      * @brief Create a set containing the variables in <variables>.
      * It is advised to have the variables in <arr> in ascending order.
      */
-    static BddSet fromVector(const std::vector<Bdd> variables) {
+    static BddSet fromVector(const std::vector<Bdd> variables)
+    {
         BddSet set;
         for (int i=variables.size()-1; i>=0; i--) {
             set.set *= variables[i];
@@ -489,7 +506,8 @@ public:
      * @brief Create a set containing the variables in <variables>.
      * It is advised to have the variables in <arr> in ascending order.
      */
-    static BddSet fromVector(const std::vector<uint32_t> variables) {
+    static BddSet fromVector(const std::vector<uint32_t> variables)
+    {
         BddSet set;
         for (int i=variables.size()-1; i>=0; i--) {
             set.add(variables[i]);
@@ -501,7 +519,8 @@ public:
      * @brief Write all variables in this set to <arr>.
      * @param arr An array of at least size this.size().
      */
-    void toArray(BDDVAR *arr) const {
+    void toArray(BDDVAR *arr) const
+    {
         if (!isEmpty()) {
             *arr = TopVar();
             Next().toArray(arr+1);
@@ -511,7 +530,8 @@ public:
     /**
      * @brief Return the vector of all variables in this set.
      */
-    std::vector<uint32_t> toVector() const {
+    std::vector<uint32_t> toVector() const
+    {
         std::vector<uint32_t> result;
         Bdd x = set;
         while (!x.isOne()) {
@@ -526,12 +546,30 @@ class BddMap
 {
     friend class Bdd;
     BDD bdd;
-    BddMap(const BDD from) : bdd(from) { sylvan_protect(&bdd); }
-    BddMap(const Bdd &from) : bdd(from.bdd) { sylvan_protect(&bdd); }
+
+    BddMap(const BDD from)
+        : bdd(from)
+    {
+        sylvan_protect(&bdd);
+    }
+
+    BddMap(const Bdd &from)
+        : BddMap(from.bdd)
+    {}
+
 public:
-    BddMap(const BddMap& from) : bdd(from.bdd) { sylvan_protect(&bdd); }
-    BddMap() : bdd(sylvan_map_empty()) { sylvan_protect(&bdd); }
-    ~BddMap() { sylvan_unprotect(&bdd); }
+    BddMap()
+        : BddMap(sylvan_map_empty())
+    {}
+
+    BddMap(const BddMap& from)
+        : BddMap(from.bdd)
+    {}
+
+    ~BddMap()
+    {
+        sylvan_unprotect(&bdd);
+    }
 
     BddMap(uint32_t key_variable, const Bdd value);
 

--- a/src/sylvan_obj.hpp
+++ b/src/sylvan_obj.hpp
@@ -604,11 +604,40 @@ class Mtbdd {
     friend class MtbddMap;
 
 public:
-    Mtbdd() { mtbdd = sylvan_false; mtbdd_protect(&mtbdd); }
-    Mtbdd(const MTBDD from) : mtbdd(from) { mtbdd_protect(&mtbdd); }
-    Mtbdd(const Mtbdd &from) : mtbdd(from.mtbdd) { mtbdd_protect(&mtbdd); }
-    Mtbdd(const Bdd &from) : mtbdd(from.bdd) { mtbdd_protect(&mtbdd); }
-    ~Mtbdd() { mtbdd_unprotect(&mtbdd); }
+    /**
+     * @brief Wrap a raw MTBDD from Sylvan's C interface into an Mtbdd object.
+     */
+    Mtbdd(const MTBDD from)
+        : mtbdd(from)
+    {
+      mtbdd_protect(&mtbdd);
+    }
+
+    /**
+     * @brief Default construction, representing the Boolean *False*.
+     */
+    Mtbdd()
+        : Mtbdd(sylvan_false)
+    {}
+
+    /**
+     * @brief Copy construction
+     */
+    Mtbdd(const Mtbdd &from)
+        : Mtbdd(from.mtbdd)
+    {}
+
+    /**
+     * @brief Conversion construction from Bdd object.
+     */
+    Mtbdd(const Bdd &from)
+        : Mtbdd(from.bdd)
+    {}
+
+    ~Mtbdd()
+    {
+        mtbdd_unprotect(&mtbdd);
+    }
 
     /**
      * @brief Creates a Mtbdd leaf representing the int64 value <value>
@@ -861,11 +890,35 @@ class MtbddMap
 {
     friend class Mtbdd;
     MTBDD mtbdd;
-    MtbddMap(MTBDD from) : mtbdd(from) { mtbdd_protect(&mtbdd); }
-    MtbddMap(Mtbdd &from) : mtbdd(from.mtbdd) { mtbdd_protect(&mtbdd); }
+
+    /**
+     * @brief Wrap a raw MTBDD from Sylvan's C interface into an MtbddMap object.
+     */
+    MtbddMap(MTBDD from)
+        : mtbdd(from)
+    {
+        mtbdd_protect(&mtbdd);
+    }
+
+    /**
+     * @brief Conversion construction
+     */
+    MtbddMap(Mtbdd &from)
+      : MtbddMap(from.mtbdd)
+    {}
+
 public:
-    MtbddMap() : mtbdd(mtbdd_map_empty()) { mtbdd_protect(&mtbdd); }
-    ~MtbddMap() { mtbdd_unprotect(&mtbdd); }
+    /**
+     * @brief Default construction of an empty map.
+     */
+    MtbddMap()
+        : MtbddMap(mtbdd_map_empty())
+    {}
+
+    ~MtbddMap()
+    {
+        mtbdd_unprotect(&mtbdd);
+    }
 
     MtbddMap(uint32_t key_variable, Mtbdd value);
 


### PR DESCRIPTION
At ETAPS, you (Tom van Dijk) mentioned something about fixing the C++ constructors. I tried to take a look.

- For the constructor, you cannot gain much with move-semantics. Maybe unprotecting a `sylvan_false` costs less? But, otherwise there is no difference.
- Similarly, you cannot gain anything from a move assignment as far as I can tell.

On the bright side, having done this I am confident I have refreshed my memory of using Sylvan enough to do the C++ ZDD interface, I promised.

Here are all of the changes. I personally would advocate for rebasing this branch to remove any of the commits with *move-semantics*; these changes are just code-duplication. The rest are possibly nice for maintainability.

I have tested this with *test/test_cxx* and by checking my benchmarks still compile and seem to work.