### PR TITLE
Prepend DESTDIR to CMAKE_INSTALL_PREFIX to run cpack out of the box

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,9 +167,9 @@ endif()
 string(REPLACE ";" " " PKGC_LIBS_PRIVATE "${PKGC_LIBS_PRIVATE}")
 
 install(CODE "
-  file(MAKE_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig\")
-  file(WRITE \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig/sylvan.pc\" \"
-prefix=\${CMAKE_INSTALL_PREFIX}
+  file(MAKE_DIRECTORY \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig\")
+  file(WRITE \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig/sylvan.pc\" \"
+prefix=\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}
 exec_prefix=\\\${prefix}
 libdir=\\\${prefix}/${CMAKE_INSTALL_LIBDIR}
 includedir=\\\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}


### PR DESCRIPTION
I don't know how people ever figured this out in mCRL2, but it seems that `pack -G DEB` uses a hidden environment variable called [DESTDIR](https://cmake.org/cmake/help/latest/envvar/DESTDIR.html) to overwrite the `CMAKE_INSTALL_PREFIX` such that it does not require sudo rights for making the installation package. 

With these changes generating the package works properly on Ubuntu and Fedora. This variable does not work on Windows, so this might required special attention that I did not look into. Alternatively, we would have to overwrite `CMAKE_INSTALL_PREFIX` ourselves in the CI, but this change does seem like the standard "solution".